### PR TITLE
Fix failures to run on recent npm

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -37,7 +37,7 @@ function run() {
             if (osvar === 'darwin') {
                 // MacOSX
                 yield exec('pip install six');
-                yield exec('brew install android-sdk');
+                yield exec('brew install android-commandlinetools');
                 yield sdk_installer_1.installAndroidSdk(29, 'default', 'x86', undefined);
                 yield exec(nativescriptInstallCmd);
             }

--- a/dist/index.js
+++ b/dist/index.js
@@ -33,7 +33,6 @@ function run() {
         try {
             const version = core.getInput('nativescript-version') || 'latest';
             const nativescriptInstallCmd = `npm i -g nativescript@${version}`;
-            yield exec('npm config set unsafe-perm=true');
             const osvar = process.platform.toLowerCase();
             if (osvar === 'darwin') {
                 // MacOSX

--- a/src/main.ts
+++ b/src/main.ts
@@ -8,7 +8,6 @@ async function run(): Promise<void> {
     const version = core.getInput('nativescript-version') || 'latest'
     const nativescriptInstallCmd = `npm i -g nativescript@${version}`
 
-    await exec('npm config set unsafe-perm=true')
     const osvar = process.platform.toLowerCase()
 
     if (osvar === 'darwin') {

--- a/src/main.ts
+++ b/src/main.ts
@@ -13,7 +13,7 @@ async function run(): Promise<void> {
     if (osvar === 'darwin') {
       // MacOSX
       await exec('pip install six')
-      await exec('brew install android-sdk')
+      await exec('brew install android-commandlinetools')
       await installAndroidSdk(29, 'default', 'x86', undefined)
       await exec(nativescriptInstallCmd)
     } else if (osvar === 'win32') {


### PR DESCRIPTION
I don't really know what I'm doing here, I'm usually in C++, but I'm happy to contribute this as requested in #21. Let me know if there are changes needed for whatever reason.  Note that I have not really tested this other than it did work in a github action workflow I tried it in.